### PR TITLE
Require additional rspec dependencies for Rspec 2.14.x

### DIFF
--- a/lib/remockable.rb
+++ b/lib/remockable.rb
@@ -1,4 +1,6 @@
 require 'rspec/core'
+require 'rspec/mocks'
+require 'rspec/expectations'
 
 require 'active_support/core_ext/array/conversions'
 require 'active_support/core_ext/array/extract_options'


### PR DESCRIPTION
In a Rails app, I recently updated to Rspec 2.14.4, and remockable stopped working (`undefined method 'define' for RSpec::Matchers:Module (NoMethodError)`). Seems like the reason is because Rspec now is autoloading `RSpec::Mocks` and `RSpec::Matchers` when they are called, but remockable isn't picking this up. To deal with it I explicitely require those libraries.