### PR TITLE
Give an example of passing options to a matcher.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,12 @@ The following Active Record matchers are supported:
   * `validate_associated`
   * `validate_uniqueness_of`
 
+You can of course pass options to these matchers the same way you do inside of 
+your models, for instance when dealing with has many through relationships:
+
+```ruby
+it { should have_many(:subscriptions, through: :customers) }
+```
 
 ## Contributing
 


### PR DESCRIPTION
Since Shoulda handles options very differently, I feel like it 
makes sense to show how simple it is to pass options to a matcher.

Not 100% convinced on the parens, it would be more obvious without them 
since it would match the most common model declarations.
