### PR TITLE
Add Rails 4.2 support

### DIFF
--- a/lib/remockable/active_record/have_column.rb
+++ b/lib/remockable/active_record/have_column.rb
@@ -9,9 +9,18 @@ RSpec::Matchers.define(:have_column) do
     }
   end
 
+  def column_values_match?(key, value)
+    case key
+    when :default
+      subject.class.column_defaults[column.name] == value
+    else
+      column.send(key) == value
+    end
+  end
+
   match do |actual|
     if column
-      options.all? { |key, value| column.send(key) == value }
+      options.all? { |key, value| column_values_match?(key, value) }
     end
   end
 


### PR DESCRIPTION
The intent of this pull request is to add Rails 4.2 support to the library.

Currently, there is one commit on the branch which updates the column option comparisons to use `column_defaults` when comparing the default column value. This is something that [Rails did a while ago](https://github.com/rails/rails/commit/4d3e88fc757a1b6f6c468418af01dca677e41edf) and has been the public API for getting the default value for some time before that. This change works in all 4.x versions.

There is one outstanding issue which is testing for default scopes. Currently, part of the matcher is to generate SQL from `scope.arel.to_sql` and compare it with a `relation.arel.to_sql` output. In Rails 4.2.x these values are identical and both contain `?` SQL parameter values in them - unlike Rails 4.0 and 4.1 where the values are injected into the string. I'm currently unsure the best way to modify this library to better test for a default query scope.
