### PR TITLE
Re-introduce Ruby 1.9 support

### DIFF
--- a/lib/remockable/active_model/validate_acceptance_of.rb
+++ b/lib/remockable/active_model/validate_acceptance_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_acceptance_of) do
 
   type :acceptance
 
-  valid_options %i(allow_nil accept if message on unless)
+  valid_options %w(allow_nil accept if message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_model/validate_confirmation_of.rb
+++ b/lib/remockable/active_model/validate_confirmation_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_confirmation_of) do
 
   type :confirmation
 
-  valid_options %i(if message on unless)
+  valid_options %w(if message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_model/validate_exclusion_of.rb
+++ b/lib/remockable/active_model/validate_exclusion_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_exclusion_of) do
 
   type :exclusion
 
-  valid_options %i(allow_nil allow_blank if in message on unless)
+  valid_options %w(allow_nil allow_blank if in message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_model/validate_format_of.rb
+++ b/lib/remockable/active_model/validate_format_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_format_of) do
 
   type :format
 
-  valid_options %i(allow_blank allow_nil if message on unless with without)
+  valid_options %w(allow_blank allow_nil if message on unless with without)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_model/validate_inclusion_of.rb
+++ b/lib/remockable/active_model/validate_inclusion_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_inclusion_of) do
 
   type :inclusion
 
-  valid_options %i(allow_nil allow_blank if in message on unless)
+  valid_options %w(allow_nil allow_blank if in message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_model/validate_length_of.rb
+++ b/lib/remockable/active_model/validate_length_of.rb
@@ -3,9 +3,9 @@ RSpec::Matchers.define(:validate_length_of) do
 
   type :length
 
-  unsupported_options %i(tokenizer)
+  unsupported_options %w(tokenizer)
 
-  valid_options %i(
+  valid_options %w(
     allow_blank
     allow_nil
     if

--- a/lib/remockable/active_model/validate_numericality_of.rb
+++ b/lib/remockable/active_model/validate_numericality_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_numericality_of) do
 
   type :numericality
 
-  valid_options %i(
+  valid_options %w(
     allow_nil
     equal_to
     even

--- a/lib/remockable/active_model/validate_presence_of.rb
+++ b/lib/remockable/active_model/validate_presence_of.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_presence_of) do
 
   type :presence
 
-  valid_options %i(if message on unless)
+  valid_options %w(if message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_record/accept_nested_attributes_for.rb
+++ b/lib/remockable/active_record/accept_nested_attributes_for.rb
@@ -1,8 +1,8 @@
 RSpec::Matchers.define(:accept_nested_attributes_for) do
   include Remockable::ActiveRecord::Helpers
 
-  unsupported_options %i(reject_if)
-  valid_options %i(allow_destroy limit update_only)
+  unsupported_options %w(reject_if)
+  valid_options %w(allow_destroy limit update_only)
 
   match do |actual|
     if actual_options = subject.class.nested_attributes_options[attribute]

--- a/lib/remockable/active_record/belong_to.rb
+++ b/lib/remockable/active_record/belong_to.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:belong_to) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(
+  valid_options %w(
     autosave
     class_name
     counter_cache

--- a/lib/remockable/active_record/have_and_belong_to_many.rb
+++ b/lib/remockable/active_record/have_and_belong_to_many.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:have_and_belong_to_many) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(
+  valid_options %w(
     association_foreign_key
     autosave
     class_name

--- a/lib/remockable/active_record/have_column.rb
+++ b/lib/remockable/active_record/have_column.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:have_column) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(default limit null precision scale type)
+  valid_options %w(default limit null precision scale type)
 
   def column
     @column ||= subject.class.columns.detect { |column|

--- a/lib/remockable/active_record/have_default_scope.rb
+++ b/lib/remockable/active_record/have_default_scope.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:have_default_scope) do
 
   attr_accessor :relation
 
-  valid_options %i()
+  valid_options []
 
   match do |actual|
     if subject.class.respond_to?(:all)
@@ -29,7 +29,7 @@ RSpec::Matchers.define(:have_default_scope) do
   end
 
   def method_missing(method, *args, &block)
-    unsupported_query_methods = %i(
+    unsupported_query_methods = %w(
       create_with
       eager_load
       includes
@@ -38,7 +38,7 @@ RSpec::Matchers.define(:have_default_scope) do
       readonly
     )
 
-    query_methods = %i(
+    query_methods = %w(
       from
       group
       having
@@ -49,7 +49,7 @@ RSpec::Matchers.define(:have_default_scope) do
       reorder
       select
       where
-    )
+    ).map(&:to_sym)
 
     if query_methods.include?(method)
       self.relation ||= subject.class.unscoped

--- a/lib/remockable/active_record/have_index.rb
+++ b/lib/remockable/active_record/have_index.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:have_index) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(name unique)
+  valid_options %w(name unique)
 
   def column_names
     @column_names ||= expected_as_array.flatten.collect(&:to_s)

--- a/lib/remockable/active_record/have_many.rb
+++ b/lib/remockable/active_record/have_many.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:have_many) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(
+  valid_options %w(
     as
     autosave
     class_name

--- a/lib/remockable/active_record/have_one.rb
+++ b/lib/remockable/active_record/have_one.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:have_one) do
   include Remockable::ActiveRecord::Helpers
 
-  valid_options %i(
+  valid_options %w(
     class_name
     dependent
     foreign_key

--- a/lib/remockable/active_record/have_scope.rb
+++ b/lib/remockable/active_record/have_scope.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:have_scope) do |*name|
 
   attr_accessor :relation
 
-  valid_options %i(with)
+  valid_options %w(with)
 
   match do |actual|
     if subject.class.respond_to?(attribute)
@@ -32,9 +32,9 @@ RSpec::Matchers.define(:have_scope) do |*name|
   end
 
   def method_missing(method, *args, &block)
-    unsupported_query_methods = %(create_with)
+    unsupported_query_methods = %w(create_with)
 
-    query_methods = %i(
+    query_methods = %w(
       eager_load
       from
       group
@@ -50,7 +50,7 @@ RSpec::Matchers.define(:have_scope) do |*name|
       reorder
       select
       where
-    )
+    ).map(&:to_sym)
 
     if query_methods.include?(method)
       self.relation ||= subject.class.all

--- a/lib/remockable/active_record/validate_associated.rb
+++ b/lib/remockable/active_record/validate_associated.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define(:validate_associated) do
 
   type :associated
 
-  valid_options %i(if message on unless)
+  valid_options %w(if message on unless)
 
   match do |actual|
     validator = validator_for(attribute)

--- a/lib/remockable/active_record/validate_uniqueness_of.rb
+++ b/lib/remockable/active_record/validate_uniqueness_of.rb
@@ -5,7 +5,7 @@ RSpec::Matchers.define :validate_uniqueness_of do |expected|
 
   type :uniqueness
 
-  valid_options %i(
+  valid_options %w(
     allow_blank
     allow_nil
     case_sensitive

--- a/lib/remockable/helpers.rb
+++ b/lib/remockable/helpers.rb
@@ -13,13 +13,13 @@ module Remockable
 
       def unsupported_options(keys)
         define_method :unsupported_options do
-          keys
+          keys.map(&:to_sym)
         end
       end
 
       def valid_options(keys)
         define_method :valid_options do
-          keys
+          keys.map(&:to_sym)
         end
       end
     end


### PR DESCRIPTION
This reintroduces Ruby 1.9 support to remockable. Rails 4.x still supports Ruby 1.9.  From [the Rails upgrading guide](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html):

> Rails 5 requires Ruby 2.2 or newer.
> Rails 4 prefers Ruby 2.0 and requires 1.9.3 or newer.