### PR TITLE
Remove unused `unsupported_query_methods` variables

### DIFF
--- a/lib/remockable/active_record/have_default_scope.rb
+++ b/lib/remockable/active_record/have_default_scope.rb
@@ -29,15 +29,6 @@ RSpec::Matchers.define(:have_default_scope) do
   end
 
   def method_missing(method, *args, &block)
-    unsupported_query_methods = %w(
-      create_with
-      eager_load
-      includes
-      lock
-      preload
-      readonly
-    )
-
     query_methods = %w(
       from
       group

--- a/lib/remockable/active_record/have_scope.rb
+++ b/lib/remockable/active_record/have_scope.rb
@@ -32,8 +32,6 @@ RSpec::Matchers.define(:have_scope) do |*name|
   end
 
   def method_missing(method, *args, &block)
-    unsupported_query_methods = %w(create_with)
-
     query_methods = %w(
       eager_load
       from


### PR DESCRIPTION
There are two local definitions of `unsupported_query_methods` variables in the library which appear to be unused.