### PR TITLE
Fix circular argument reference error in Ruby 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  * Fix circular reference error in Ruby 2.2 ([Nathaniel Bibler][nbibler])
   * Restore support for Ruby 1.9 ([Nathaniel Bibler][nbibler])
 
 ## 0.3.0 (2014-07-21)

--- a/lib/remockable/active_model/helpers.rb
+++ b/lib/remockable/active_model/helpers.rb
@@ -16,7 +16,7 @@ module Remockable
         end
       end
 
-      def options_match(validator, options=options)
+      def options_match(validator, options=self.options)
         actual = validator.options.slice(*(options.keys - CONDITIONALS))
         actual == options.except(*CONDITIONALS)
       end


### PR DESCRIPTION
In Ruby 2.2, nearly all local gem specs fail (and application specs fail, as well, when integrated). There is a circular reference in the ActiveModel helpers:

```
/remockable/lib/remockable/active_model/helpers.rb:19: warning: circular argument reference - options
```

This causes `options` to errantly be set to `nil` in Ruby 2.2, rather than to the local `options` method return value as intended. This manifests itself as the following exception:

```
NoMethodError:
   undefined method `keys' for nil:NilClass
```